### PR TITLE
Add summernote-map-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ This curated list is on very early stage. So, let's make it together!
    - Uploadcare plugin for Summernote. It will allow your users to upload files and images from local device, social networks, cloud storages without any backend code that is usually required to handle uploads.
  - [summernote-rtl-plugin](https://github.com/virtser/summernote-rtl-plugin)
    - Summernote RTL plugin. This extensions allows to add two new buttons to Summernote editor toolbar. Those buttons let user change text direction to either LTR (left to right) or RTL (right to left).
+ - [summernote-map-plugin](https://github.com/maiyaporn/summernote-map-plugin)
+   - A plugin for adding map to Summernote. It allows users to search for places with autocomplete (Google Places API) and add an embed map of the selected place to editor.
 
 ### Misc
  - [summernote-ext-print](https://github.com/lqez/summernote-ext-print)


### PR DESCRIPTION
This is a plugin for adding map to [Summernote WYSIWYG] editor. It allows users to search for places with autocomplete (Google Places API) and add an embed map of the selected place to editor.
