### PR TITLE
Add Summernote Codewrapper Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This curated list is on very early stage. So, let's make it together!
    - Based on code-prettify the summernote code highlighting plugin
  - [summernote-ace-plugin](https://github.com/wubin1989/summernote-ace-plugin)
    - Based on Ace(https://ace.c9.io/#nav=about) the summernote code highlighting plugin
+ - [summernote-ext-codewrapper](https://github.com/semplon/summernote-ext-codewrapper)
+   - This will wrap code inside `pre` tag by selecting them. see video for demo.
 
 ### Emojis
  - [summernote-emojione-plugin](https://github.com/bmironov/summernote-emojione-plugin)


### PR DESCRIPTION
This extension will wrap selected text and put it inside `pre` tag. This was made because the default summernote code styler always create new line when we styling selected text. And when we paste code into editor, not all code are formatted automatically by summernote. 

i hope this will be useful 

see video for demo 

https://www.youtube.com/watch?v=TTUgPvp6DQs
