### PR TITLE
Added summernote-ext-emoji-ajax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ This curated list is on very early stage. So, let's make it together!
    - Dropdown list of my favorite emojiOne images, embedded as base64 strings for easy portability
  - [summernote-emoji-ext](https://github.com/nilobarp/summernote-ext-emoji)
    - Emoji plugin for summernote
+ - [summernote-ext-emoji-ajax](https://github.com/tylerecouture/summernote-ext-emoji-ajax/)
+   - Uses the github emoji api and loads them via ajax.
 
 ### Special Characters & Icons
  - [summernote-ext-specialchars](https://github.com/JustinEldracher/summernote-plugins/tree/master/summernote-ext-specialchars)


### PR DESCRIPTION
All the other emoji extensions I tried were either old/broken or weren't doing it for me. Mostly I had problems with the browser stalling as it loaded the images, and the styling didn't match the rest of summernote.

This extension uses the github emoji source, similar to the Summernote Emoji Hint example, except it uses AJAX asynch.