### PR TITLE
Add summernote-gallery plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ This curated list is on very early stage. So, let's make it together!
    - Summernote plugin to insert audio by URL or file upload
  - [summernote-bricks](https://github.com/eissasoubhi/summernote-bricks)
    - A summernote module to add user-friendly components to the WYSIWYG editor.
+ - [summernote-gallery](https://github.com/eissasoubhi/summernote-gallery)
+   - A simple bootstrap image-gallery modal to add images with the real path to the server instead of using base64 encoding.
  - [summernote-ext-elfinder](https://github.com/semplon/summernote-ext-elfinder)
    - Summernote Plugin for elFinder File Manager
    - [Connector Instructions Wiki on elFinder's Repository](https://github.com/Studio-42/elFinder/wiki/Integration-with-Multiple-Summernote-%28fixed-functions%29)


### PR DESCRIPTION
A summernote-gallery plugin that provides a bootstrap image-gallery modal to select images from the server and add them to summernote editor with the real path to the server instead of using base64 encoding.